### PR TITLE
Use jQuery .on() to listen for events, rather than .click()

### DIFF
--- a/cornell-catalog-demo/app/assets/javascripts/integrateLinks.js
+++ b/cornell-catalog-demo/app/assets/javascripts/integrateLinks.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 	//getDerivativeWorks();
 	//getEditions();
-	$('*[data-auth]').click(
+	$(this).on('click', '*[data-auth]',
 			function() {
 				var e = $(this);
 				e.off('click');


### PR DESCRIPTION
This change allows the Knowledge Panel to reload upon being clicked a second time.
Per https://stackoverflow.com/a/14187154/8748686